### PR TITLE
Fix typo of sudo in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ user_name="$USER"
 sudo apt install xfce4-appmenu-plugin appmenu-* -y
 
 #Xfce4 plugins
-sud apt install xfce4-indicator-plugin xfce4-statusnotifier-plugin xfce4-power-manager xfce4-pulseaudio-plugin xfce4-notifyd -y
+sudo apt install xfce4-indicator-plugin xfce4-statusnotifier-plugin xfce4-power-manager xfce4-pulseaudio-plugin xfce4-notifyd -y
 
 #GTK theme
 git clone https://github.com/vinceliuice/WhiteSur-gtk-theme.git


### PR DESCRIPTION
In install.sh, when installing the Xfce4 plugins, the sudo command has a typo, being called `sud`. Simple little PR to just fix that typo.